### PR TITLE
do not install gcc 12

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,6 @@ apt install -y \
     git \
     gcc g++ gfortran \
     gcc-10 gfortran-10 g++-10 \
-    gcc-12 gfortran-12 g++-12 \
     bash-completion \
     tree \
     git \


### PR DESCRIPTION
Installing this compiler causes failures in the basics section.