### PR TITLE
Add spack group to AMI generation for caches tutorial

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -105,6 +105,12 @@ for i in `seq 1 10`; do
     sudo usermod -aG docker "spack${i}"
 done
 
+echo "== Creating a group of spack users"
+sudo groupadd spack
+for i in `seq 1 10`; do
+    sudo usermod -aG spack "spack${i}"
+done
+
 echo "== Starting Docker services"
 sudo systemctl enable docker.service
 sudo systemctl enable containerd.service


### PR DESCRIPTION
We reference a spack group in the caches tutorial. This exists for the container but isn't created in the AMI.